### PR TITLE
Async Parser Support

### DIFF
--- a/src/TurnerSoftware.SitemapTools/Parser/ISitemapParser.cs
+++ b/src/TurnerSoftware.SitemapTools/Parser/ISitemapParser.cs
@@ -9,6 +9,6 @@ namespace TurnerSoftware.SitemapTools.Parser
 {
 	public interface ISitemapParser
 	{
-		SitemapFile ParseSitemap(TextReader reader);
+		Task<SitemapFile> ParseSitemapAsync(TextReader reader);
 	}
 }

--- a/src/TurnerSoftware.SitemapTools/Parser/TextSitemapParser.cs
+++ b/src/TurnerSoftware.SitemapTools/Parser/TextSitemapParser.cs
@@ -2,19 +2,18 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace TurnerSoftware.SitemapTools.Parser
 {
 	public class TextSitemapParser : ISitemapParser
 	{
-		public SitemapFile ParseSitemap(TextReader reader)
+		public async Task<SitemapFile> ParseSitemapAsync(TextReader reader)
 		{
-			var result = new SitemapFile();
-			var line = string.Empty;
-
 			var sitemapEntries = new List<SitemapEntry>();
 
-			while ((line = reader.ReadLine()) != null)
+			string line;
+			while ((line = await reader.ReadLineAsync()) != null)
 			{
 				if (Uri.TryCreate(line, UriKind.Absolute, out var tmpUri))
 				{

--- a/src/TurnerSoftware.SitemapTools/SitemapQuery.cs
+++ b/src/TurnerSoftware.SitemapTools/SitemapQuery.cs
@@ -152,9 +152,11 @@ namespace TurnerSoftware.SitemapTools
 
 								using (var streamReader = new StreamReader(contentStream))
 								{
-									var sitemap = parser.ParseSitemap(streamReader);
+									var sitemap = await parser.ParseSitemapAsync(streamReader);
 									if (sitemap != null)
+									{
 										sitemap.Location = sitemapUrl;
+									}
 									return sitemap;
 								}
 							}

--- a/src/TurnerSoftware.SitemapTools/TurnerSoftware.SitemapTools.csproj
+++ b/src/TurnerSoftware.SitemapTools/TurnerSoftware.SitemapTools.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
 
     <AssemblyName>TurnerSoftware.SitemapTools</AssemblyName>
     <Description>A sitemap (sitemap.xml) parsing and querying library in C#</Description>

--- a/tests/TurnerSoftware.SitemapTools.Tests/TextSitemapParserTests.cs
+++ b/tests/TurnerSoftware.SitemapTools.Tests/TextSitemapParserTests.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TurnerSoftware.SitemapTools.Parser;
 
@@ -11,7 +12,7 @@ namespace TurnerSoftware.SitemapTools.Tests
 	public class TextSitemapParserTests : TestBase
 	{
 		[TestMethod]
-		public void ParseTextSitemap()
+		public async Task ParseTextSitemapAsync()
 		{
 			foreach (var culture in CultureInfo.GetCultures(CultureTypes.AllCultures))
 			{
@@ -20,7 +21,7 @@ namespace TurnerSoftware.SitemapTools.Tests
 				using (var reader = LoadResource("text-sitemap.txt"))
 				{
 					var parser = new TextSitemapParser();
-					var sitemapFile = parser.ParseSitemap(reader);
+					var sitemapFile = await parser.ParseSitemapAsync(reader);
 
 					Assert.AreEqual(3, sitemapFile.Urls.Count());
 

--- a/tests/TurnerSoftware.SitemapTools.Tests/XmlSitemapParserTests.cs
+++ b/tests/TurnerSoftware.SitemapTools.Tests/XmlSitemapParserTests.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TurnerSoftware.SitemapTools.Parser;
 
@@ -11,7 +12,7 @@ namespace TurnerSoftware.SitemapTools.Tests
 	public class XmlSitemapParserTests : TestBase
 	{
 		[TestMethod]
-		public void ChangeFrequenciesAreSetCorrectly()
+		public async Task ChangeFrequenciesAreSetCorrectlyAsync()
 		{
 			foreach (var culture in CultureInfo.GetCultures(CultureTypes.AllCultures))
 			{
@@ -20,7 +21,7 @@ namespace TurnerSoftware.SitemapTools.Tests
 				using (var reader = LoadResource("basic-sitemap.xml"))
 				{
 					var parser = new XmlSitemapParser();
-					var sitemapFile = parser.ParseSitemap(reader);
+					var sitemapFile = await parser.ParseSitemapAsync(reader);
 
 					var entries = sitemapFile.Urls.Where(e => e.Location.AbsolutePath.Contains("frequency/"));
 
@@ -56,7 +57,7 @@ namespace TurnerSoftware.SitemapTools.Tests
 		}
 
 		[TestMethod]
-		public void ParseIndexFile()
+		public async Task ParseIndexFileAsync()
 		{
 			foreach (var culture in CultureInfo.GetCultures(CultureTypes.AllCultures))
 			{
@@ -65,7 +66,7 @@ namespace TurnerSoftware.SitemapTools.Tests
 				using (var reader = LoadResource("another-indexed-sitemap.xml"))
 				{
 					var parser = new XmlSitemapParser();
-					var sitemapFile = parser.ParseSitemap(reader);
+					var sitemapFile = await parser.ParseSitemapAsync(reader);
 
 					Assert.AreEqual(1, sitemapFile.Sitemaps.Count());
 
@@ -77,7 +78,7 @@ namespace TurnerSoftware.SitemapTools.Tests
 		}
 
 		[TestMethod]
-		public void ParseSitemapFile()
+		public async Task ParseSitemapFileAsync()
 		{
 			foreach (var culture in CultureInfo.GetCultures(CultureTypes.AllCultures))
 			{
@@ -86,7 +87,7 @@ namespace TurnerSoftware.SitemapTools.Tests
 				using (var reader = LoadResource("basic-sitemap.xml"))
 				{
 					var parser = new XmlSitemapParser();
-					var sitemapFile = parser.ParseSitemap(reader);
+					var sitemapFile = await parser.ParseSitemapAsync(reader);
 
 					Assert.AreEqual(12, sitemapFile.Urls.Count());
 


### PR DESCRIPTION
Previously, both the TXT and XML parsers operated synchronously. For large sitemaps, this doesn't scale as it ties up the CPU thread waiting on IO resources while reading in the sitemap.

Instead, switching to an asynchronous model, it can release the CPU thread for other work while waiting on IO operations.